### PR TITLE
Install requests type definitions in dev mode

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ dev =
     pytest >= 6, < 7
     pytest-mock
     requests-mock
+    types-requests
     wheel
 
 [options.packages.find]


### PR DESCRIPTION
Latest version of mypy removed some of the type definitions from the package. Those are now available in a separate Python package that we added to the development extras.